### PR TITLE
Open a new PR only if there are diffs (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # required for creating a branch and PR
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: weglot/translate-action@v1
@@ -50,13 +51,13 @@ jobs:
 | `api-key` | Yes | - | Weglot API key. |
 | `source-path` | Yes | - | Path or glob to source file(s), e.g. `locales/en.json` or `locales/**/*.json`. |
 | `output-dir` | No | (same as source) | Directory for translated files. |
-| `output-mode` | No | `files` | `files` = write to disk; `pr` = create a branch and open a PR. |
+| `output-mode` | No | `files` | `files` = write to disk; `pr` = create a branch and open a PR **only if** translated files differ from the current branch. |
 | `languages` | No | (from project) | Comma-separated target codes (e.g. `fr,de`). If empty, uses all languages from your Weglot project. |
 | `pr-branch` | No | (auto) | Branch name when `output-mode: pr`. |
 
 ## Outputs
 
 - `output-path`: Directory where translated files were written (`files` mode).
-- `pr-url`: URL of the created pull request (`pr` mode).
+- `pr-url`: URL of the created pull request (`pr` mode). Set only when a PR was opened; omitted if there were no file changes.
 
 In workflow expressions, use bracket notation for hyphenated outputs, e.g. `${{ steps.<id>.outputs['output-path'] }}`.

--- a/dist/index.js
+++ b/dist/index.js
@@ -148,11 +148,19 @@ async function createPullRequest(workspace, writtenPaths, prBranchInput) {
     await exec("git", ["config", "user.email", "github-actions[bot]@users.noreply.github.com"], {
         cwd: workspace,
     });
-    await exec("git", ["checkout", "-b", branchName], { cwd: workspace });
     for (const p of writtenPaths) {
         const relative = path_1.default.relative(workspace, p);
-        await exec("git", ["add", relative], { cwd: workspace });
+        await exec("git", ["add", "--", relative], { cwd: workspace });
     }
+    const diffExitCode = await exec("git", ["diff", "--cached", "--quiet"], {
+        cwd: workspace,
+        ignoreReturnCode: true,
+    });
+    if (diffExitCode === 0) {
+        core.info("No translation changes compared to the current branch; skipping pull request.");
+        return;
+    }
+    await exec("git", ["checkout", "-b", branchName], { cwd: workspace });
     await exec("git", ["commit", "-m", "Add Weglot translated localization files"], {
         cwd: workspace,
     });
@@ -169,5 +177,12 @@ async function createPullRequest(workspace, writtenPaths, prBranchInput) {
     });
     core.setOutput("pr-url", pr.data.html_url);
     core.info(`Pull request created: ${pr.data.html_url}`);
+    try {
+        await exec("git", ["checkout", defaultBranch], { cwd: workspace });
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        core.warning(`Could not check out the default branch (${defaultBranch}) after creating the PR: ${message}`);
+    }
 }
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,12 +166,24 @@ async function createPullRequest(
       cwd: workspace,
     }
   );
-  await exec("git", ["checkout", "-b", branchName], { cwd: workspace });
 
   for (const p of writtenPaths) {
     const relative = path.relative(workspace, p);
-    await exec("git", ["add", relative], { cwd: workspace });
+    await exec("git", ["add", "--", relative], { cwd: workspace });
   }
+
+  const diffExitCode = await exec("git", ["diff", "--cached", "--quiet"], {
+    cwd: workspace,
+    ignoreReturnCode: true,
+  });
+  if (diffExitCode === 0) {
+    core.info(
+      "No translation changes compared to the current branch; skipping pull request."
+    );
+    return;
+  }
+
+  await exec("git", ["checkout", "-b", branchName], { cwd: workspace });
 
   await exec(
     "git",
@@ -189,6 +201,7 @@ async function createPullRequest(
         | { default_branch?: string }
         | undefined
     )?.default_branch ?? "main";
+
   const pr = await octokit.rest.pulls.create({
     base: defaultBranch,
     body: "This PR was created by the Weglot Translate Action with the latest translations.",
@@ -199,6 +212,15 @@ async function createPullRequest(
   });
   core.setOutput("pr-url", pr.data.html_url);
   core.info(`Pull request created: ${pr.data.html_url}`);
+
+  try {
+    await exec("git", ["checkout", defaultBranch], { cwd: workspace });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    core.warning(
+      `Could not check out the default branch (${defaultBranch}) after creating the PR: ${message}`
+    );
+  }
 }
 
 main();


### PR DESCRIPTION
Closes #3 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to PR-creation control flow and git commands; main risk is altering automation expectations when no translations change.
> 
> **Overview**
> The action’s `output-mode: pr` flow now stages translated files and checks for any staged diff before creating a branch/commit/PR; if nothing changed, it logs and exits without opening a PR (so `pr-url` is not set).
> 
> Hardens the git staging command by using `git add -- <path>` and attempts to checkout the repo default branch after PR creation, warning (not failing) if that cleanup step can’t be done. Documentation is updated to require `pull-requests: write` permission and to clarify the conditional PR behavior/output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34817939c0e0843d1c9797f18f05ac3844b1a1c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->