### PR TITLE
Add CODEOWNERS (#15)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @nico2che @weglot/integrations-review
+package.json 


### PR DESCRIPTION
Closes #15 
@nico2che possible d'ajouter l'accès en write à @weglot/integrations-review stp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a `CODEOWNERS` file to auto-request reviewers/owners, with no runtime or product code changes.
> 
> **Overview**
> Adds `.github/CODEOWNERS` to set default repository ownership/reviewers (`*`) and a specific rule for `package.json`, ensuring PRs automatically request the listed owners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a086604134fef5516f6e85f22c032dbfc837aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->