### PR TITLE
Add comment trigger to refresh translations in PR mode (#18)

### DIFF
--- a/.github/workflows/test-pr-mode.yml
+++ b/.github/workflows/test-pr-mode.yml
@@ -1,0 +1,27 @@
+name: Test Translate Action (PR mode)
+
+on:
+  push:
+    branches: [master]
+  issue_comment:
+    types: [created]
+
+jobs:
+  test-translate-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Weglot Translate (pr mode)
+        uses: ./
+        with:
+          api-key: ${{ secrets.WEGLOT_API_KEY }}
+          source-path: test/fixtures/locales/en.json
+          output-mode: pr
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,4 @@ jobs:
         run: |
           cat test/fixtures/locales/fr.json
           test -f test/fixtures/locales/fr.json && echo "fr.json created" || exit 1
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,42 @@ GitHub Action to translate localization files using your [Weglot](https://weglot
     languages: fr,de,es
 ```
 
+### Refresh translations on demand (comment trigger)
+
+If you update translations directly in the Weglot dashboard and want to pull those changes into the open PR without pushing new source-file commits, you can comment `/update` on the PR. The action re-fetches translations from Weglot and pushes a new commit if anything changed, then replies with the result.
+
+Add `issue_comment` as a second trigger — the action handles the `/update` check itself:
+
+```yaml
+name: Translate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - locales/en.json
+  issue_comment:
+    types: [created]
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history needed for git rebase in pr mode
+      - uses: weglot/translate-action@v1
+        with:
+          api-key: ${{ secrets.WEGLOT_API_KEY }}
+          source-path: locales/en.json
+          output-mode: pr
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Create a PR with translations
 
 In **`output-mode: pr`**, the action uses a deterministic branch name `translations/<16-char-hex>` derived from your **`source-path`**, **`output-dir`**, and **API key** (hashed; the key is never placed in the branch name). **Target languages are not part of the hash**, so adding a language in Weglot or changing the `languages` input updates the same branch and the same open PR. Use different `source-path` and/or `output-dir` (or a different Weglot project key) for a second job in the same repository.
@@ -47,8 +83,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-JavaScript actions do not receive `GITHUB_TOKEN` in the environment automatically—you must pass **`github-token`** (usually `${{ secrets.GITHUB_TOKEN }}`, same as `github.token`).
-
 ## Inputs
 
 | Input | Required | Default | Description |
@@ -58,7 +92,7 @@ JavaScript actions do not receive `GITHUB_TOKEN` in the environment automaticall
 | `output-dir` | No | (same as source) | Directory for translated files. |
 | `output-mode` | No | `files` | `files` = write to disk; `pr` = push to deterministic branch `translations/<hash>` and open or update one PR per stream (see above). |
 | `languages` | No | (from project) | Comma-separated target codes (e.g. `fr,de`). If empty, uses all languages from your Weglot project. |
-| `github-token` | When `output-mode: pr` | - | Token for the GitHub API and `git push`. Use `${{ secrets.GITHUB_TOKEN }}`. Job needs `contents: write` and `pull-requests: write`. |
+| `github-token` | When `output-mode: pr` | - | Token for the GitHub API and `git push`. Use `${{ secrets.GITHUB_TOKEN }}`. Job needs `contents: write`, `issues: write`, and `pull-requests: write`. |
 
 ## Outputs
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -33925,6 +33925,7 @@ function getOctokit(token, options, ...additionalPlugins) {
 const CDN_BASE = "https://cdn.weglot.com";
 const API_BASE = "https://cdn-api-weglot.com";
 const API_MAX_LENGTH = 600;
+const UPDATE_COMMENT_TRIGGER = "/update";
 
 async function fetchProjectSettings(apiKey) {
     const settingsKey = apiKey.startsWith("wg_") ? apiKey.slice(3) : apiKey;
@@ -34131,111 +34132,28 @@ function computeTranslationPrBranchName(options) {
     return `translations/${digest}`;
 }
 
-function filterLanguages(languagesInput, configuredLanguages) {
-    return languagesInput
-        .split(",")
-        .map(l => l.trim())
-        .filter(code => {
-        const ok = !!configuredLanguages.find(l => l.custom_code === code || l.language_to === code);
-        if (ok) {
-            return true;
-        }
-        warning(`Language "${code}" is not configured in your Weglot project; skipping.`);
-        return false;
-    });
+function issueCommentNumber() {
+    if (context.eventName !== "issue_comment") {
+        return undefined;
+    }
+    const payload = context.payload;
+    return payload.issue?.number;
 }
-async function main() {
+async function postComment(octokit, owner, repo, body) {
+    const issueNumber = issueCommentNumber();
+    if (issueNumber === undefined) {
+        return;
+    }
     try {
-        const apiKey = getInput("api-key", { required: true }).trim();
-        if (!apiKey) {
-            setFailed("api-key is required");
-            return;
-        }
-        const sourcePath = getInput("source-path", { required: true }).trim();
-        const outputDir = getInput("output-dir", { required: false }).trim();
-        const outputMode = (getInput("output-mode", { required: false }) || "files").toLowerCase();
-        const languagesInput = getInput("languages", { required: false })
-            .trim();
-        const githubToken = (getInput("github-token", { required: false }).trim() ||
-            process.env.GITHUB_TOKEN ||
-            "").trim();
-        const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
-        info("Fetching Weglot project settings...");
-        const settings = await fetchProjectSettings(apiKey);
-        const language_from = settings.language_from;
-        const versions = settings.versions;
-        const version = versions?.translations != null ? String(versions.translations) : "1";
-        const languagesFromSettings = (settings.languages ?? []);
-        const targetLanguages = languagesInput
-            ? filterLanguages(languagesInput, languagesFromSettings)
-            : languagesFromSettings.map(l => l.language_to);
-        if (targetLanguages.length === 0) {
-            setFailed("No target languages to translate.");
-            return;
-        }
-        info(`Source language: ${language_from}. Target languages: ${targetLanguages.join(", ")}`);
-        const sourceFiles = await resolveSourceFiles(sourcePath, workspace);
-        if (sourceFiles.length === 0) {
-            setFailed(`No files matched: ${sourcePath}`);
-            return;
-        }
-        info(`Found ${sourceFiles.length} source file(s).`);
-        const requestUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY
-            ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
-            : "https://github.com";
-        const writtenPaths = [];
-        for (const sourceFilePath of sourceFiles) {
-            const relativePath = path.relative(workspace, sourceFilePath);
-            if (!relativePath.endsWith(".json")) {
-                warning(`Skipping non-JSON file: ${relativePath}`);
-                continue;
-            }
-            const obj = await readJson(sourceFilePath);
-            const { paths, values } = extractLeafStrings(obj);
-            if (values.length === 0) {
-                info(`No strings to translate in ${relativePath}`);
-                continue;
-            }
-            for (const lTo of targetLanguages) {
-                info(`Translating ${relativePath} -> ${lTo}...`);
-                const translated = await translateStrings({
-                    apiKey,
-                    lFrom: language_from,
-                    lTo,
-                    requestUrl,
-                    strings: values,
-                    version,
-                });
-                const translatedObj = applyTranslations(obj, paths, translated);
-                const outPath = getOutputPath(relativePath, lTo, language_from, outputDir, workspace);
-                await writeJson(outPath, translatedObj);
-                writtenPaths.push(outPath);
-            }
-        }
-        if (writtenPaths.length === 0) {
-            setFailed("No translated files were written.");
-            return;
-        }
-        const outputBase = outputDir ? path.join(workspace, outputDir) : workspace;
-        setOutput("output-path", outputBase);
-        if (outputMode === "pr") {
-            if (!githubToken) {
-                setFailed("PR mode requires a GitHub token. Add to your workflow: github-token: ${{ secrets.GITHUB_TOKEN }} (and permissions: contents: write, pull-requests: write).");
-                return;
-            }
-            const prBranchName = computeTranslationPrBranchName({
-                apiKey,
-                outputDir,
-                sourcePath,
-            });
-            setOutput("pr-branch", prBranchName);
-            info(`PR branch: ${prBranchName}`);
-            await createPullRequest(workspace, writtenPaths, prBranchName, githubToken);
-        }
+        await octokit.rest.issues.createComment({
+            body,
+            issue_number: issueNumber,
+            owner,
+            repo,
+        });
     }
     catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        setFailed(message);
+        warning(`Could not post comment to PR #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`);
     }
 }
 async function createPullRequest(workspace, writtenPaths, branchName, githubToken) {
@@ -34319,6 +34237,7 @@ async function createPullRequest(workspace, writtenPaths, branchName, githubToke
             if (existingUrl) {
                 setOutput("pr-url", existingUrl);
                 info(`No new translation changes after rebasing onto ${defaultBranch}; open PR unchanged: ${existingUrl}`);
+                await postComment(octokit, owner, repo, "Translations are already up to date — no changes from Weglot.");
             }
             else {
                 info(`No translation changes to commit on ${branchName} and no open PR found.`);
@@ -34352,6 +34271,7 @@ async function createPullRequest(workspace, writtenPaths, branchName, githubToke
             info(`Updated existing pull request branch ${branchName}: ${prUrl}`);
         }
         setOutput("pr-url", prUrl);
+        await postComment(octokit, owner, repo, "Translations have been refreshed with the latest content from Weglot.");
     }
     finally {
         // Try to restore initial branch in all cases.
@@ -34372,6 +34292,160 @@ async function createPullRequest(workspace, writtenPaths, branchName, githubToke
         if (stashAfterBranch === "pending") {
             await popWeglotStash();
         }
+    }
+}
+
+function filterLanguages(languagesInput, configuredLanguages) {
+    return languagesInput
+        .split(",")
+        .map(l => l.trim())
+        .filter(code => {
+        const ok = !!configuredLanguages.find(l => l.custom_code === code || l.language_to === code);
+        if (ok) {
+            return true;
+        }
+        warning(`Language "${code}" is not configured in your Weglot project; skipping.`);
+        return false;
+    });
+}
+async function main() {
+    try {
+        const isIssueComment = context.eventName === "issue_comment";
+        // When triggered by a PR comment, only proceed for the UPDATE_COMMENT_TRIGGER command
+        // on the translations PR — ignore everything else silently.
+        if (isIssueComment) {
+            const payload = context.payload;
+            if (payload.comment?.body?.trim() !== UPDATE_COMMENT_TRIGGER) {
+                info(`Skipping: not a "${UPDATE_COMMENT_TRIGGER}" comment.`);
+                return;
+            }
+        }
+        // Inputs
+        const apiKey = getInput("api-key", { required: true }).trim();
+        if (!apiKey) {
+            setFailed("api-key is required");
+            return;
+        }
+        const sourcePath = getInput("source-path", { required: true }).trim();
+        const outputDir = getInput("output-dir", { required: false }).trim();
+        const outputMode = (getInput("output-mode", { required: false }) || "files").toLowerCase();
+        const languagesInput = getInput("languages", { required: false })
+            .trim();
+        const githubToken = (getInput("github-token", { required: false }).trim() ||
+            process.env.GITHUB_TOKEN ||
+            "").trim();
+        // Guard: verify the comment was posted on the translations PR, not any other PR.
+        if (isIssueComment) {
+            if (outputMode !== "pr") {
+                info(`Skipping: "${UPDATE_COMMENT_TRIGGER}" only applies in pr mode.`);
+                return;
+            }
+            const issueNumber = context.payload.issue?.number;
+            if (issueNumber !== undefined && githubToken) {
+                const octokit = getOctokit(githubToken);
+                const { owner, repo } = context.repo;
+                const expectedBranch = computeTranslationPrBranchName({
+                    apiKey,
+                    outputDir,
+                    sourcePath,
+                });
+                try {
+                    const { data: pr } = await octokit.rest.pulls.get({
+                        owner,
+                        pull_number: issueNumber,
+                        repo,
+                    });
+                    if (pr.head.ref !== expectedBranch) {
+                        info(`Skipping: "${UPDATE_COMMENT_TRIGGER}" was not posted on the translations PR.`);
+                        return;
+                    }
+                }
+                catch {
+                    info("Skipping: could not verify PR branch.");
+                    return;
+                }
+            }
+        }
+        // Project settings
+        const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+        info("Fetching Weglot project settings...");
+        const settings = await fetchProjectSettings(apiKey);
+        const language_from = settings.language_from;
+        const versions = settings.versions;
+        const version = versions?.translations != null ? String(versions.translations) : "1";
+        const languagesFromSettings = (settings.languages ?? []);
+        const targetLanguages = languagesInput
+            ? filterLanguages(languagesInput, languagesFromSettings)
+            : languagesFromSettings.map(l => l.language_to);
+        if (targetLanguages.length === 0) {
+            setFailed("No target languages to translate.");
+            return;
+        }
+        info(`Source language: ${language_from}. Target languages: ${targetLanguages.join(", ")}`);
+        // Translate
+        const sourceFiles = await resolveSourceFiles(sourcePath, workspace);
+        if (sourceFiles.length === 0) {
+            setFailed(`No files matched: ${sourcePath}`);
+            return;
+        }
+        info(`Found ${sourceFiles.length} source file(s).`);
+        const requestUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY
+            ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
+            : "https://github.com";
+        const writtenPaths = [];
+        for (const sourceFilePath of sourceFiles) {
+            const relativePath = path.relative(workspace, sourceFilePath);
+            if (!relativePath.endsWith(".json")) {
+                warning(`Skipping non-JSON file: ${relativePath}`);
+                continue;
+            }
+            const obj = await readJson(sourceFilePath);
+            const { paths, values } = extractLeafStrings(obj);
+            if (values.length === 0) {
+                info(`No strings to translate in ${relativePath}`);
+                continue;
+            }
+            for (const lTo of targetLanguages) {
+                info(`Translating ${relativePath} -> ${lTo}...`);
+                const translated = await translateStrings({
+                    apiKey,
+                    lFrom: language_from,
+                    lTo,
+                    requestUrl,
+                    strings: values,
+                    version,
+                });
+                const translatedObj = applyTranslations(obj, paths, translated);
+                const outPath = getOutputPath(relativePath, lTo, language_from, outputDir, workspace);
+                await writeJson(outPath, translatedObj);
+                writtenPaths.push(outPath);
+            }
+        }
+        if (writtenPaths.length === 0) {
+            setFailed("No translated files were written.");
+            return;
+        }
+        const outputBase = outputDir ? path.join(workspace, outputDir) : workspace;
+        setOutput("output-path", outputBase);
+        // PR mode: push translated files to a dedicated branch and open/update the PR
+        if (outputMode === "pr") {
+            if (!githubToken) {
+                setFailed("PR mode requires a GitHub token. Add to your workflow: github-token: ${{ secrets.GITHUB_TOKEN }} (and permissions: contents: write, pull-requests: write).");
+                return;
+            }
+            const prBranchName = computeTranslationPrBranchName({
+                apiKey,
+                outputDir,
+                sourcePath,
+            });
+            setOutput("pr-branch", prBranchName);
+            info(`PR branch: ${prBranchName}`);
+            await createPullRequest(workspace, writtenPaths, prBranchName, githubToken);
+        }
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setFailed(message);
     }
 }
 main();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ export default tseslint.config(
       },
     },
     rules: {
+      "curly": ["error", "all"],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
 export const CDN_BASE = "https://cdn.weglot.com";
 export const API_BASE = "https://cdn-api-weglot.com";
 export const API_MAX_LENGTH = 600;
+export const UPDATE_COMMENT_TRIGGER = "/update";

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,232 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import path from "path";
+import { popWeglotStash, runGit, STASH_MESSAGE } from "./helpers.js";
+
+export function issueCommentNumber(): number | undefined {
+  if (github.context.eventName !== "issue_comment") {
+    return undefined;
+  }
+  const payload = github.context.payload as { issue?: { number?: number } };
+  return payload.issue?.number;
+}
+
+export async function postComment(
+  octokit: ReturnType<typeof github.getOctokit>,
+  owner: string,
+  repo: string,
+  body: string
+): Promise<void> {
+  const issueNumber = issueCommentNumber();
+  if (issueNumber === undefined) {
+    return;
+  }
+  try {
+    await octokit.rest.issues.createComment({
+      body,
+      issue_number: issueNumber,
+      owner,
+      repo,
+    });
+  } catch (err) {
+    core.warning(
+      `Could not post comment to PR #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+export async function createPullRequest(
+  workspace: string,
+  writtenPaths: string[],
+  branchName: string,
+  githubToken: string
+): Promise<void> {
+  const octokit = github.getOctokit(githubToken);
+  const { owner, repo } = github.context.repo;
+  const defaultBranch =
+    (
+      github.context.payload.repository as
+        | { default_branch?: string }
+        | undefined
+    )?.default_branch ?? "main";
+
+  await runGit(["config", "user.name", "github-actions[bot]"], false);
+  await runGit(
+    ["config", "user.email", "github-actions[bot]@users.noreply.github.com"],
+    false
+  );
+
+  const relativeWritten = writtenPaths.map(p => path.relative(workspace, p));
+
+  const fetchOpenPrUrl = async (): Promise<string | undefined> => {
+    const { data } = await octokit.rest.pulls.list({
+      head: `${owner}:${branchName}`,
+      owner,
+      per_page: 1,
+      repo,
+      state: "open",
+    });
+    return data[0]?.html_url;
+  };
+
+  // Refresh origin; decide between "new branch" and "track existing translations/*".
+  await runGit(["fetch", "origin"], false);
+
+  const remoteBranchExists =
+    (await runGit(["rev-parse", "--verify", `origin/${branchName}`])) === 0;
+
+  if (relativeWritten.length > 0) {
+    await runGit(["add", "--", ...relativeWritten], false);
+  }
+
+  // Stash staged translations so checkout/merge cannot strand them on the wrong branch.
+  const stashCode = await runGit([
+    "stash",
+    "push",
+    "-m",
+    STASH_MESSAGE,
+    "--staged",
+  ]);
+  if (stashCode !== 0) {
+    core.setFailed(
+      "Could not stash translation changes before switching branches."
+    );
+    return;
+  }
+
+  let stashAfterBranch: "pending" | "applied" | "pop_failed" = "pending";
+  try {
+    // Check out PR branch; if it already exists remotely, rebase it onto default first.
+    if (remoteBranchExists) {
+      if (
+        (await runGit([
+          "checkout",
+          "-B",
+          branchName,
+          `origin/${branchName}`,
+        ])) !== 0
+      ) {
+        core.setFailed(`Could not check out origin/${branchName}.`);
+        return;
+      }
+      if ((await runGit(["rebase", `origin/${defaultBranch}`])) !== 0) {
+        await runGit(["rebase", "--abort"]);
+        core.setFailed(
+          `Rebase of ${branchName} onto origin/${defaultBranch} failed. Resolve conflicts locally on that branch.`
+        );
+        return;
+      }
+    } else {
+      if (
+        (await runGit([
+          "checkout",
+          "-B",
+          branchName,
+          `origin/${defaultBranch}`,
+        ])) !== 0
+      ) {
+        core.setFailed(
+          `Could not create branch ${branchName} from origin/${defaultBranch}.`
+        );
+        return;
+      }
+    }
+
+    // Checks if we created a stash earlier (if there was no change, no stash is created so the pop will fail)
+    if (!(await popWeglotStash())) {
+      stashAfterBranch = "pop_failed";
+      core.setFailed(
+        "Could not apply stashed translations (conflicts?). Fix conflicts and run again."
+      );
+      return;
+    }
+    stashAfterBranch = "applied";
+
+    if (relativeWritten.length > 0) {
+      await runGit(["add", "--", ...relativeWritten], false);
+    }
+
+    // Index matches HEAD (e.g. rebase + same content) → no commit/push.
+    if ((await runGit(["diff", "--cached", "--quiet"])) === 0) {
+      const existingUrl = await fetchOpenPrUrl();
+      if (existingUrl) {
+        core.setOutput("pr-url", existingUrl);
+        core.info(
+          `No new translation changes after rebasing onto ${defaultBranch}; open PR unchanged: ${existingUrl}`
+        );
+        await postComment(
+          octokit,
+          owner,
+          repo,
+          "Translations are already up to date — no changes from Weglot."
+        );
+      } else {
+        core.info(
+          `No translation changes to commit on ${branchName} and no open PR found.`
+        );
+      }
+      return;
+    }
+
+    await runGit(
+      ["commit", "-m", "Update Weglot translated localization files"],
+      false
+    );
+
+    // Push updates the branch; open a PR only when none exists for this head.
+    // After rebase, history may diverge from origin → force-with-lease (not plain force).
+    const pushCode = remoteBranchExists
+      ? await runGit(["push", "--force-with-lease", "-u", "origin", branchName])
+      : await runGit(["push", "-u", "origin", branchName]);
+    if (pushCode !== 0) {
+      core.setFailed(`git push failed for ${branchName}.`);
+      return;
+    }
+
+    let prUrl = await fetchOpenPrUrl();
+    if (!prUrl) {
+      const pr = await octokit.rest.pulls.create({
+        base: defaultBranch,
+        body: "This PR was created by the Weglot Translate Action with the latest translations.",
+        head: branchName,
+        owner,
+        repo,
+        title: "Add Weglot translated localization files",
+      });
+      prUrl = pr.data.html_url;
+      core.info(`Pull request created: ${prUrl}`);
+    } else {
+      core.info(`Updated existing pull request branch ${branchName}: ${prUrl}`);
+    }
+    core.setOutput("pr-url", prUrl);
+    await postComment(
+      octokit,
+      owner,
+      repo,
+      "Translations have been refreshed with the latest content from Weglot."
+    );
+  } finally {
+    // Try to restore initial branch in all cases.
+    if ((await runGit(["checkout", "-"])) === 0) {
+      core.info("Restored initial branch.");
+    } else if (
+      process.env.GITHUB_REF_NAME &&
+      (await runGit(["checkout", process.env.GITHUB_REF_NAME])) === 0
+    ) {
+      core.info(
+        `Checked out GITHUB_REF_NAME (${process.env.GITHUB_REF_NAME}).`
+      );
+    } else if ((await runGit(["checkout", defaultBranch])) === 0) {
+      core.info(`Checked out repository default branch (${defaultBranch}).`);
+    } else {
+      core.warning(
+        `Could not restore the original branch. You may still be on "${branchName}".`
+      );
+    }
+
+    // Aborted before successful checkout/pop: put stashed translations back on this branch.
+    if (stashAfterBranch === "pending") {
+      await popWeglotStash();
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,9 @@ import {
   writeJson,
 } from "./file-types/json.js";
 import { resolveSourceFiles, getOutputPath } from "./files.js";
-import {
-  computeTranslationPrBranchName,
-  popWeglotStash,
-  runGit,
-  STASH_MESSAGE,
-} from "./helpers.js";
+import { computeTranslationPrBranchName } from "./helpers.js";
+import { createPullRequest } from "./github.js";
+import { UPDATE_COMMENT_TRIGGER } from "./constants.js";
 
 function filterLanguages(
   languagesInput: string,
@@ -45,6 +42,21 @@ function filterLanguages(
 
 async function main(): Promise<void> {
   try {
+    const isIssueComment = github.context.eventName === "issue_comment";
+
+    // When triggered by a PR comment, only proceed for the UPDATE_COMMENT_TRIGGER command
+    // on the translations PR — ignore everything else silently.
+    if (isIssueComment) {
+      const payload = github.context.payload as {
+        comment?: { body?: string };
+      };
+      if (payload.comment?.body?.trim() !== UPDATE_COMMENT_TRIGGER) {
+        core.info(`Skipping: not a "${UPDATE_COMMENT_TRIGGER}" comment.`);
+        return;
+      }
+    }
+
+    // Inputs
     const apiKey = core.getInput("api-key", { required: true }).trim();
     if (!apiKey) {
       core.setFailed("api-key is required");
@@ -65,6 +77,45 @@ async function main(): Promise<void> {
       ""
     ).trim();
 
+    // Guard: verify the comment was posted on the translations PR, not any other PR.
+    if (isIssueComment) {
+      if (outputMode !== "pr") {
+        core.info(
+          `Skipping: "${UPDATE_COMMENT_TRIGGER}" only applies in pr mode.`
+        );
+        return;
+      }
+      const issueNumber = (
+        github.context.payload as { issue?: { number?: number } }
+      ).issue?.number;
+      if (issueNumber !== undefined && githubToken) {
+        const octokit = github.getOctokit(githubToken);
+        const { owner, repo } = github.context.repo;
+        const expectedBranch = computeTranslationPrBranchName({
+          apiKey,
+          outputDir,
+          sourcePath,
+        });
+        try {
+          const { data: pr } = await octokit.rest.pulls.get({
+            owner,
+            pull_number: issueNumber,
+            repo,
+          });
+          if (pr.head.ref !== expectedBranch) {
+            core.info(
+              `Skipping: "${UPDATE_COMMENT_TRIGGER}" was not posted on the translations PR.`
+            );
+            return;
+          }
+        } catch {
+          core.info("Skipping: could not verify PR branch.");
+          return;
+        }
+      }
+    }
+
+    // Project settings
     const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
 
     core.info("Fetching Weglot project settings...");
@@ -90,6 +141,7 @@ async function main(): Promise<void> {
       `Source language: ${language_from}. Target languages: ${targetLanguages.join(", ")}`
     );
 
+    // Translate
     const sourceFiles = await resolveSourceFiles(sourcePath, workspace);
     if (sourceFiles.length === 0) {
       core.setFailed(`No files matched: ${sourcePath}`);
@@ -148,6 +200,7 @@ async function main(): Promise<void> {
     const outputBase = outputDir ? path.join(workspace, outputDir) : workspace;
     core.setOutput("output-path", outputBase);
 
+    // PR mode: push translated files to a dedicated branch and open/update the PR
     if (outputMode === "pr") {
       if (!githubToken) {
         core.setFailed(
@@ -172,190 +225,6 @@ async function main(): Promise<void> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     core.setFailed(message);
-  }
-}
-
-async function createPullRequest(
-  workspace: string,
-  writtenPaths: string[],
-  branchName: string,
-  githubToken: string
-): Promise<void> {
-  const octokit = github.getOctokit(githubToken);
-  const { owner, repo } = github.context.repo;
-  const defaultBranch =
-    (
-      github.context.payload.repository as
-        | { default_branch?: string }
-        | undefined
-    )?.default_branch ?? "main";
-
-  await runGit(["config", "user.name", "github-actions[bot]"], false);
-  await runGit(
-    ["config", "user.email", "github-actions[bot]@users.noreply.github.com"],
-    false
-  );
-
-  const relativeWritten = writtenPaths.map(p => path.relative(workspace, p));
-
-  const fetchOpenPrUrl = async (): Promise<string | undefined> => {
-    const { data } = await octokit.rest.pulls.list({
-      head: `${owner}:${branchName}`,
-      owner,
-      per_page: 1,
-      repo,
-      state: "open",
-    });
-    return data[0]?.html_url;
-  };
-
-  // Refresh origin; decide between "new branch" and "track existing translations/*".
-  await runGit(["fetch", "origin"], false);
-
-  const remoteBranchExists =
-    (await runGit(["rev-parse", "--verify", `origin/${branchName}`])) === 0;
-
-  if (relativeWritten.length > 0) {
-    await runGit(["add", "--", ...relativeWritten], false);
-  }
-
-  // Stash staged translations so checkout/merge cannot strand them on the wrong branch.
-  const stashCode = await runGit([
-    "stash",
-    "push",
-    "-m",
-    STASH_MESSAGE,
-    "--staged",
-  ]);
-  if (stashCode !== 0) {
-    core.setFailed(
-      "Could not stash translation changes before switching branches."
-    );
-    return;
-  }
-
-  let stashAfterBranch: "pending" | "applied" | "pop_failed" = "pending";
-  try {
-    // Check out PR branch; if it already exists remotely, rebase it onto default first.
-    if (remoteBranchExists) {
-      if (
-        (await runGit([
-          "checkout",
-          "-B",
-          branchName,
-          `origin/${branchName}`,
-        ])) !== 0
-      ) {
-        core.setFailed(`Could not check out origin/${branchName}.`);
-        return;
-      }
-      if ((await runGit(["rebase", `origin/${defaultBranch}`])) !== 0) {
-        await runGit(["rebase", "--abort"]);
-        core.setFailed(
-          `Rebase of ${branchName} onto origin/${defaultBranch} failed. Resolve conflicts locally on that branch.`
-        );
-        return;
-      }
-    } else {
-      if (
-        (await runGit([
-          "checkout",
-          "-B",
-          branchName,
-          `origin/${defaultBranch}`,
-        ])) !== 0
-      ) {
-        core.setFailed(
-          `Could not create branch ${branchName} from origin/${defaultBranch}.`
-        );
-        return;
-      }
-    }
-
-    // Checks if we created a stash earlier (if there was no change, no stash is created so the pop will fail)
-    if (!(await popWeglotStash())) {
-      stashAfterBranch = "pop_failed";
-      core.setFailed(
-        "Could not apply stashed translations (conflicts?). Fix conflicts and run again."
-      );
-      return;
-    }
-    stashAfterBranch = "applied";
-
-    if (relativeWritten.length > 0) {
-      await runGit(["add", "--", ...relativeWritten], false);
-    }
-
-    // Index matches HEAD (e.g. rebase + same content) → no commit/push.
-    if ((await runGit(["diff", "--cached", "--quiet"])) === 0) {
-      const existingUrl = await fetchOpenPrUrl();
-      if (existingUrl) {
-        core.setOutput("pr-url", existingUrl);
-        core.info(
-          `No new translation changes after rebasing onto ${defaultBranch}; open PR unchanged: ${existingUrl}`
-        );
-      } else {
-        core.info(
-          `No translation changes to commit on ${branchName} and no open PR found.`
-        );
-      }
-      return;
-    }
-
-    await runGit(
-      ["commit", "-m", "Update Weglot translated localization files"],
-      false
-    );
-
-    // Push updates the branch; open a PR only when none exists for this head.
-    // After rebase, history may diverge from origin → force-with-lease (not plain force).
-    const pushCode = remoteBranchExists
-      ? await runGit(["push", "--force-with-lease", "-u", "origin", branchName])
-      : await runGit(["push", "-u", "origin", branchName]);
-    if (pushCode !== 0) {
-      core.setFailed(`git push failed for ${branchName}.`);
-      return;
-    }
-
-    let prUrl = await fetchOpenPrUrl();
-    if (!prUrl) {
-      const pr = await octokit.rest.pulls.create({
-        base: defaultBranch,
-        body: "This PR was created by the Weglot Translate Action with the latest translations.",
-        head: branchName,
-        owner,
-        repo,
-        title: "Add Weglot translated localization files",
-      });
-      prUrl = pr.data.html_url;
-      core.info(`Pull request created: ${prUrl}`);
-    } else {
-      core.info(`Updated existing pull request branch ${branchName}: ${prUrl}`);
-    }
-    core.setOutput("pr-url", prUrl);
-  } finally {
-    // Try to restore initial branch in all cases.
-    if ((await runGit(["checkout", "-"])) === 0) {
-      core.info("Restored initial branch.");
-    } else if (
-      process.env.GITHUB_REF_NAME &&
-      (await runGit(["checkout", process.env.GITHUB_REF_NAME])) === 0
-    ) {
-      core.info(
-        `Checked out GITHUB_REF_NAME (${process.env.GITHUB_REF_NAME}).`
-      );
-    } else if ((await runGit(["checkout", defaultBranch])) === 0) {
-      core.info(`Checked out repository default branch (${defaultBranch}).`);
-    } else {
-      core.warning(
-        `Could not restore the original branch. You may still be on "${branchName}".`
-      );
-    }
-
-    // Aborted before successful checkout/pop: put stashed translations back on this branch.
-    if (stashAfterBranch === "pending") {
-      await popWeglotStash();
-    }
   }
 }
 


### PR DESCRIPTION
Closes #18 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR-mode git/Octokit flows and introduces a new comment-triggered execution path; mistakes could cause unintended runs or comment spam, though guards limit it to `/update` on the translations PR.
> 
> **Overview**
> Adds an on-demand refresh flow for `output-mode: pr`: when the workflow is triggered by an `issue_comment`, the action now only runs for a `/update` comment and verifies the comment is on the expected `translations/<hash>` PR branch before re-fetching translations.
> 
> In PR mode, the action now posts a PR comment indicating whether translations were refreshed or were already up to date, and updates docs/workflows to include the required `issue_comment` trigger plus `issues: write` permission. The PR also refactors PR-creation logic into a new `src/github.ts`, adds `UPDATE_COMMENT_TRIGGER` constant, and tightens linting with an ESLint `curly` rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a59a4ba2ed5dbe29d13b99c1e730c819fc0292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->