### PR TITLE
Use custom_code for file paths (#22)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34299,13 +34299,18 @@ function filterLanguages(languagesInput, configuredLanguages) {
     return languagesInput
         .split(",")
         .map(l => l.trim())
-        .filter(code => {
-        const ok = !!configuredLanguages.find(l => l.custom_code === code || l.language_to === code);
-        if (ok) {
-            return true;
+        .flatMap(code => {
+        const found = configuredLanguages.find(l => l.custom_code === code || l.language_to === code);
+        if (!found) {
+            warning(`Language "${code}" is not configured in your Weglot project; skipping.`);
+            return [];
         }
-        warning(`Language "${code}" is not configured in your Weglot project; skipping.`);
-        return false;
+        return [
+            {
+                languageTo: found.language_to,
+                code: found.custom_code ?? found.language_to,
+            },
+        ];
     });
 }
 async function main() {
@@ -34376,12 +34381,15 @@ async function main() {
         const languagesFromSettings = (settings.languages ?? []);
         const targetLanguages = languagesInput
             ? filterLanguages(languagesInput, languagesFromSettings)
-            : languagesFromSettings.map(l => l.language_to);
+            : languagesFromSettings.map(l => ({
+                languageTo: l.language_to,
+                code: l.custom_code ?? l.language_to,
+            }));
         if (targetLanguages.length === 0) {
             setFailed("No target languages to translate.");
             return;
         }
-        info(`Source language: ${language_from}. Target languages: ${targetLanguages.join(", ")}`);
+        info(`Source language: ${language_from}. Target languages: ${targetLanguages.map(l => l.code).join(", ")}`);
         // Translate
         const sourceFiles = await resolveSourceFiles(sourcePath, workspace);
         if (sourceFiles.length === 0) {
@@ -34405,18 +34413,18 @@ async function main() {
                 info(`No strings to translate in ${relativePath}`);
                 continue;
             }
-            for (const lTo of targetLanguages) {
-                info(`Translating ${relativePath} -> ${lTo}...`);
+            for (const lang of targetLanguages) {
+                info(`Translating ${relativePath} -> ${lang.code}...`);
                 const translated = await translateStrings({
                     apiKey,
                     lFrom: language_from,
-                    lTo,
+                    lTo: lang.languageTo,
                     requestUrl,
                     strings: values,
                     version,
                 });
                 const translatedObj = applyTranslations(obj, paths, translated);
-                const outPath = getOutputPath(relativePath, lTo, language_from, outputDir, workspace);
+                const outPath = getOutputPath(relativePath, lang.code, language_from, outputDir, workspace);
                 await writeJson(outPath, translatedObj);
                 writtenPaths.push(outPath);
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,29 +14,37 @@ import { computeTranslationPrBranchName } from "./helpers.js";
 import { createPullRequest } from "./github.js";
 import { UPDATE_COMMENT_TRIGGER } from "./constants.js";
 
+interface LanguageTarget {
+  languageTo: string;
+  code: string;
+}
+
 function filterLanguages(
   languagesInput: string,
   configuredLanguages: Array<{
     language_to: string;
     custom_code?: string;
   }>
-): string[] {
+): LanguageTarget[] {
   return languagesInput
     .split(",")
     .map(l => l.trim())
-    .filter(code => {
-      const ok = !!configuredLanguages.find(
+    .flatMap(code => {
+      const found = configuredLanguages.find(
         l => l.custom_code === code || l.language_to === code
       );
-      if (ok) {
-        return true;
+      if (!found) {
+        core.warning(
+          `Language "${code}" is not configured in your Weglot project; skipping.`
+        );
+        return [];
       }
-
-      core.warning(
-        `Language "${code}" is not configured in your Weglot project; skipping.`
-      );
-
-      return false;
+      return [
+        {
+          languageTo: found.language_to,
+          code: found.custom_code ?? found.language_to,
+        },
+      ];
     });
 }
 
@@ -129,16 +137,19 @@ async function main(): Promise<void> {
       custom_code?: string;
     }>;
 
-    const targetLanguages = languagesInput
+    const targetLanguages: LanguageTarget[] = languagesInput
       ? filterLanguages(languagesInput, languagesFromSettings)
-      : languagesFromSettings.map(l => l.language_to);
+      : languagesFromSettings.map(l => ({
+          languageTo: l.language_to,
+          code: l.custom_code ?? l.language_to,
+        }));
 
     if (targetLanguages.length === 0) {
       core.setFailed("No target languages to translate.");
       return;
     }
     core.info(
-      `Source language: ${language_from}. Target languages: ${targetLanguages.join(", ")}`
+      `Source language: ${language_from}. Target languages: ${targetLanguages.map(l => l.code).join(", ")}`
     );
 
     // Translate
@@ -169,12 +180,12 @@ async function main(): Promise<void> {
         continue;
       }
 
-      for (const lTo of targetLanguages) {
-        core.info(`Translating ${relativePath} -> ${lTo}...`);
+      for (const lang of targetLanguages) {
+        core.info(`Translating ${relativePath} -> ${lang.code}...`);
         const translated = await translateStrings({
           apiKey,
           lFrom: language_from,
-          lTo,
+          lTo: lang.languageTo,
           requestUrl,
           strings: values,
           version,
@@ -182,7 +193,7 @@ async function main(): Promise<void> {
         const translatedObj = applyTranslations(obj, paths, translated);
         const outPath = getOutputPath(
           relativePath,
-          lTo,
+          lang.code,
           language_from,
           outputDir,
           workspace


### PR DESCRIPTION
Closes #22 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the mapping between configured languages and output file paths; risk is mainly around generating files under different names/locations, which can impact downstream tooling or PR diffs.
> 
> **Overview**
> Translation targets are now tracked as `{ languageTo, code }` pairs, so the action can **translate using Weglot’s `language_to`** while **writing output files and logs using `custom_code` (falling back to `language_to`)**.
> 
> `filterLanguages` was updated to return these structured targets (and to skip/warn on unconfigured inputs), and the translation loop now passes `languageTo` to the API and `code` into `getOutputPath`, affecting the generated per-language file paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f73832f4b092bdf40db585cb9735650b667cd8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->