### PR TITLE
Use correct translation version for Weglot API (#26)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33925,8 +33925,10 @@ async function translateStrings(opts) {
         const params = new URLSearchParams({
             api_key: apiKey,
             s: String(s),
-            v: version,
         });
+        if (version) {
+            params.set("v", String(version));
+        }
         const url = `${API_BASE}/translate?${params.toString()}`;
         const res = await fetch(url, {
             method: "POST",
@@ -34304,7 +34306,7 @@ async function main() {
         const settings = await fetchProjectSettings(apiKey);
         const language_from = settings.language_from;
         const versions = settings.versions;
-        const version = versions?.translations != null ? String(versions.translations) : "1";
+        const version = versions?.translation;
         const languagesFromSettings = (settings.languages ?? []);
         const targetLanguages = languagesInput
             ? filterLanguages(languagesInput, languagesFromSettings)

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,8 +130,7 @@ async function main(): Promise<void> {
     const settings = await fetchProjectSettings(apiKey);
     const language_from = settings.language_from as string;
     const versions = settings.versions as Record<string, unknown> | undefined;
-    const version =
-      versions?.translations != null ? String(versions.translations) : "1";
+    const version = versions?.translation as number | undefined;
     const languagesFromSettings = (settings.languages ?? []) as Array<{
       language_to: string;
       custom_code?: string;

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -6,7 +6,7 @@ export interface TranslateOptions {
   lTo: string;
   requestUrl: string;
   strings: string[];
-  version: string;
+  version?: number;
 }
 
 export async function translateStrings(
@@ -35,8 +35,10 @@ export async function translateStrings(
     const params = new URLSearchParams({
       api_key: apiKey,
       s: String(s),
-      v: version,
     });
+    if (version) {
+      params.set("v", String(version));
+    }
     const url = `${API_BASE}/translate?${params.toString()}`;
     const res = await fetch(url, {
       method: "POST",


### PR DESCRIPTION
Closes #26 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to how Weglot API requests are parameterized; main risk is behavior change for users who previously relied on the hardcoded default version.
> 
> **Overview**
> Uses `settings.versions.translation` (number) as the translation version instead of `versions.translations`/defaulting to `"1"`, aligning the action with Weglot’s project settings.
> 
> Updates `translateStrings` so `version` is optional and the `v` query parameter is only added when a version is present, preventing requests from always sending a potentially incorrect/default version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8258a1663b84fe61cae0de2e5ad60710549ce397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->