### PR TITLE
Prepare repository for open source release (#17)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings
+* text=auto
+
+# Exclude from git archive exports
+.* export-ignore
+node_modules export-ignore
+test export-ignore
+yarn.lock export-ignore
+*.config.* export-ignore
+tsconfig*.json export-ignore
+jest.config.js export-ignore
+
+# Exclude from GitHub Linguist language statistics
+dist/** linguist-generated
+node_modules/** linguist-vendored
+test/** linguist-detectable=false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**Workflow configuration**
+```yaml
+# Paste the relevant part of your workflow file
+```
+
+**Action inputs**
+- `source-path`:
+- `output-mode`:
+- `languages`:
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened. Include any error messages from the Actions log.
+
+**Versions**
+- Action version (e.g. `@v1`):
+- Runner OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+labels: enhancement
+---
+
+**What problem does this solve?**
+A clear description of the use case or limitation you're hitting.
+
+**Proposed solution**
+How you'd like this to work.
+
+**Alternatives considered**
+Any workarounds or alternative approaches you've thought about.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dependencies-major:
+        dependency-type: "production"
+        update-types:
+          - "major"
+      dev-dependencies:
+        dependency-type: "development"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What
+
+<!-- What does this PR change? -->
+
+## Why
+
+<!-- Why is this change needed? Link to an issue if applicable. -->
+
+## Checklist
+
+- [ ] `yarn build` run and `dist/` updated
+- [ ] `yarn test` passes
+- [ ] `yarn lint` passes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Lint
+        run: yarn lint
+
       - name: Build and test
         run: yarn test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-04-08
+
+### Added
+- Initial release
+- Translate JSON localization files via the Weglot API (`files` mode)
+- `pr` mode: push translations to a deterministic branch and open/update a PR
+- `/update` comment trigger to refresh translations on an open PR
+- Glob support for `source-path`
+- `output-dir` and `languages` inputs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# Claude Code — Weglot Translate Action
+
+## Commands
+
+```bash
+yarn build          # compile TS → lib/, bundle → dist/index.js
+yarn test           # build + jest
+yarn lint           # eslint src/
+```
+
+Node version: see `.nvmrc`. Package manager: Yarn 1.22.22.
+
+## Critical: dist/ must be committed
+
+`dist/index.js` is what GitHub Actions executes. It is **not** gitignored. Every PR that changes `src/` must include an updated `dist/` built with `yarn build`.
+
+## Project structure
+
+```
+src/
+  index.ts          entry point — reads action inputs, orchestrates translate + output
+  translate.ts      Weglot API call (translate strings)
+  settings.ts       Weglot API call (fetch project settings / languages)
+  files.ts          glob resolution, output path computation
+  helpers.ts        branch name hashing, misc utilities
+  github.ts         git operations + GitHub API (PR create/update, comments)
+  constants.ts      shared constants (e.g. UPDATE_COMMENT_TRIGGER)
+  file-types/
+    json.ts         JSON read/write, leaf-string extraction and re-application
+dist/               bundled single-file output (committed)
+lib/                compiled TS (intermediate, gitignored)
+test/
+  *.test.ts         Jest unit tests
+  fixtures/         sample locale files used by tests and CI integration
+```
+
+## Action inputs / outputs
+
+Defined in `action.yml`. Two output modes:
+- `files` — writes translated files alongside sources
+- `pr` — pushes to a deterministic branch `translations/<hex>` and opens/updates one PR
+
+The PR branch name is derived from `source-path`, `output-dir`, and the API key (hashed — key never appears in the branch name). See `helpers.ts`.
+
+## CI
+
+- `.github/workflows/test.yml` — build, unit tests, and a live `files` mode integration test
+- `.github/workflows/test-pr-mode.yml` — live `pr` mode integration test (runs on push to master and `/update` comments)
+
+Both workflows require a `WEGLOT_API_KEY` repository secret.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Weglot Translate Action
+
+Thank you for your interest in contributing!
+
+## Requirements
+
+- Node.js >= 20 (see `.nvmrc`)
+- Yarn 1.22.22
+
+## Local setup
+
+```bash
+# Install dependencies
+yarn install
+
+# Build (compiles TypeScript → lib/, then bundles → dist/)
+yarn build
+
+# Run tests
+yarn test
+
+# Lint
+yarn lint
+```
+
+## Project structure
+
+```
+src/          TypeScript source
+dist/         Bundled output committed to the repo (single dist/index.js)
+lib/          Compiled JS/d.ts (intermediate, not committed)
+test/         Jest unit tests + fixtures
+```
+
+## Important: committing `dist/`
+
+`dist/index.js` is the file GitHub Actions actually runs. It must be committed alongside every source change. Always run `yarn build` before committing, and include the updated `dist/` in your PR.
+
+## Submitting a pull request
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes in `src/`.
+3. Run `yarn build && yarn test && yarn lint` — all must pass.
+4. Commit both source and the updated `dist/`.
+5. Open a PR against `master` with a clear description of what and why.
+
+## Reporting issues
+
+Please use the GitHub issue templates for bug reports and feature requests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Weglot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest major version receives security updates.
+
+| Version | Supported          |
+|---------|--------------------|
+| 1.x     | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please do **not** open a public GitHub issue for security vulnerabilities.
+
+Instead, use GitHub's private vulnerability reporting:
+[Privately report a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability)
+
+Once received, we will review the report and respond as quickly as possible. We appreciate responsible disclosure and will credit reporters in the release notes.


### PR DESCRIPTION
Closes #17 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily repository metadata/docs and GitHub templates, with the only behavioral change being an added `yarn lint` step in CI that may cause new build failures if lint issues exist.
> 
> **Overview**
> Prepares the repo for an open-source release by adding standard project/community files: `LICENSE` (MIT), `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, issue templates, and a PR template.
> 
> Adds repo-wide formatting/packaging hygiene via `.editorconfig` and `.gitattributes` (line-ending normalization, archive export ignores, and Linguist settings), and updates the CI `test.yml` workflow to run `yarn lint` before tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862d066a8d85b2e778404a5dd53e1be5a733cf21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->