### PR TITLE
Document scheduled sync and add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/test-pr-mode.yml
+++ b/.github/workflows/test-pr-mode.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   issue_comment:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   test-translate-pr:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,39 @@ GitHub Action to translate localization files using your [Weglot](https://weglot
     languages: fr,de,es
 ```
 
+### Scheduled sync (keep repo in sync with Dashboard edits automatically)
+
+If you edit translations directly in the Weglot Dashboard, you can have the action pull those changes into the repo on a schedule — no manual comment or source-file push required. Add a `schedule:` trigger (and optionally `workflow_dispatch:` for on-demand runs):
+
+```yaml
+name: Sync translations from Weglot
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # nightly at 03:00 UTC
+  workflow_dispatch:        # allow manual trigger from the Actions tab
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history needed for git rebase in pr mode
+      - uses: weglot/translate-action@v1
+        with:
+          api-key: ${{ secrets.WEGLOT_API_KEY }}
+          source-path: locales/en.json
+          output-mode: pr
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The action fetches the latest translations from Weglot (including any Dashboard edits) and opens or updates a `translations/<hash>` PR if anything changed. If the repo is already in sync, it exits cleanly with no commit or PR.
+
 ### Refresh translations on demand (comment trigger)
 
 If you update translations directly in the Weglot dashboard and want to pull those changes into the open PR without pushing new source-file commits, you can comment `/update` on the PR. The action re-fetches translations from Weglot and pushes a new commit if anything changed, then replies with the result.


### PR DESCRIPTION
Closes #40

Adds a "Scheduled sync" section to the README showing how to use a `schedule:` / `workflow_dispatch:` trigger to pull Dashboard edits automatically via cron. Also adds `workflow_dispatch:` to `test-pr-mode.yml` so the scheduled path can be tested manually from the Actions tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus enabling manual triggering of an existing GitHub Actions workflow; no runtime code or translation logic is modified.
> 
> **Overview**
> Adds documentation for running `weglot/translate-action` in a **scheduled sync** setup, including an example `schedule` + `workflow_dispatch` workflow that keeps translations in sync by opening/updating a `translations/<hash>` PR.
> 
> Updates the `test-pr-mode.yml` GitHub Actions workflow to also support `workflow_dispatch`, allowing the existing PR-mode test job to be triggered manually from the Actions tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17cd6307d0c0f1a70f94bd537248fdfe460dae54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->