### PR TITLE
Ignore TypeScript major updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,8 @@ updates:
           - "major"
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # typescript-eslint does not support TS 7 yet (see #66)
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Dependabot bundled the TypeScript 6 → 7 major into a weekly dev-dependency patch PR, which broke CI at the lint step since no released typescript-eslint accepts TS 7. TypeScript major updates are now ignored in `.github/dependabot.yml`, to be removed once #66 is resolved.

Closes #67

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependabot-only configuration; no runtime or application code changes.
> 
> **Overview**
> Dependabot will no longer open PRs for **TypeScript semver-major** bumps (e.g. 6 → 7).
> 
> The ignore rule is scoped to the `typescript` package only and is documented as temporary until **typescript-eslint** supports TS 7 ([#66](https://github.com/...)). Weekly minor/patch updates for TypeScript remain eligible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4754827088b99cdc99590d8ecd3524152a60378b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->